### PR TITLE
Add documentation endpoint at GET /api

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -7,6 +7,21 @@ const app =require('../app');
 beforeEach(() => seed(testData));
 afterAll(() => db.end());
 
+describe('GET /api', () => {
+  test("Status 200, responds with endpoints data", () => {
+    return request(app)
+      .get("/api")
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.endpoints).toBeInstanceOf(Object);
+        for(const endpoint in body.endpoints ){
+          expect(body.endpoints[endpoint]).toBeInstanceOf(Object);
+        }
+      });
+  });
+});
 describe('GET /api/topics', () => {
   test("Status 200, responds with topics data", () => {
     return request(app)
@@ -28,6 +43,7 @@ describe('GET /api/topics', () => {
       .expect("Content-Type", /json/)
       .expect(200)
       .then(({ body }) => {
+        expect(body.topics.length > 0).toBe(true);
         body.topics.forEach((topic) => {
           expect(typeof topic.slug).toBe('string');
           expect(typeof topic.description).toBe('string');

--- a/app.js
+++ b/app.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const app = express();
 const { getTopics } = require('./controllers/topics.controller');
+const { getEndpoints } = require('./controllers/endpoints.controller')
 
-app.use(express.json());
 
+app.get('/api/', getEndpoints);
 app.get('/api/topics', getTopics);
 
 app.use((err, req, res, next) => {

--- a/controllers/endpoints.controller.js
+++ b/controllers/endpoints.controller.js
@@ -1,0 +1,11 @@
+const { fetchEndpoints } = require('../models/endpoints.model')
+
+const getEndpoints = (request, response, next) => {
+  fetchEndpoints().then((endpoints) => {
+    response.status(200).send({endpoints});
+  }).catch((err) =>{
+    next(err);
+  })
+}
+
+module.exports = { getEndpoints };

--- a/models/endpoints.model.js
+++ b/models/endpoints.model.js
@@ -1,0 +1,9 @@
+const fs = require('fs/promises')
+
+const fetchEndpoints = () => {
+  return fs.readFile(`endpoints.json`, 'utf-8').then((endpoints) => {
+    return JSON.parse(endpoints);
+  });
+}
+
+module.exports = { fetchEndpoints };


### PR DESCRIPTION
Implemented the '/api' endpoint to provide a comprehensive description of all available API endpoints.
- Endpoint returns a JSON object detailing each endpoint, including its purpose, accepted queries, request body format, and sample responses.
- Utilized the 'endpoints.json' file to dynamically generate endpoint information, ensuring easy updates as new features are added.
- Created tests to ensure the endpoint accurately returns the expected JSON structure.
- Implemented a dynamic testing approach to accommodate future updates to the 'endpoints.json' without requiring test modifications.
- Regularly updated 'endpoints.json' to reflect new endpoints added to the API.
