### PR TITLE
Add endpoint to fetch comments for an article by ID

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,107 +1,197 @@
-const request = require('supertest');
-const db = require('../db/connection');
-const seed = require('../db/seeds/seed');
-const testData = require('../db/data/test-data');
-const app = require('../app');
-const endpoints =  require('../endpoints.json');
+const request = require('supertest')
+const db = require('../db/connection')
+const seed = require('../db/seeds/seed')
+const testData = require('../db/data/test-data')
+const app = require('../app')
+const endpoints = require('../endpoints.json')
 
-beforeEach(() => seed(testData));
-afterAll(() => db.end());
+beforeEach(() => seed(testData))
+afterAll(() => db.end())
 
 describe('GET /api', () => {
-  test("Status 200, responds with endpoints data", () => {
+  test('Status 200, responds with endpoints data', () => {
     return request(app)
-      .get("/api")
-      .set("Accept", "application/json")
-      .expect("Content-Type", /json/)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
       .expect(200)
       .then(({ body }) => {
-        expect(body.endpoints).toBeInstanceOf(Object);
-        expect(body.endpoints).toEqual(endpoints);
-      });
-  });
-});
+        expect(body.endpoints).toBeInstanceOf(Object)
+        expect(body.endpoints).toEqual(endpoints)
+      })
+  })
+})
 describe('GET /api/topics', () => {
-  test("Status 200, responds correct topic data", () => {
+  test('Status 200, responds correct topic data', () => {
     return request(app)
-      .get("/api/topics")
-      .set("Accept", "application/json")
-      .expect("Content-Type", /json/)
+      .get('/api/topics')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
       .expect(200)
       .then(({ body }) => {
-        expect(body.topics).toBeInstanceOf(Array);
-        expect(body.topics.length > 0).toBe(true);
-        body.topics.forEach((topic) =>{
-          expect(topic).toBeInstanceOf(Object);
-          expect(typeof topic.slug).toBe('string');
-          expect(typeof topic.description).toBe('string');
+        expect(body.topics).toBeInstanceOf(Array)
+        expect(body.topics.length > 0).toBe(true)
+        body.topics.forEach((topic) => {
+          expect(topic).toBeInstanceOf(Object)
+          expect(typeof topic.slug).toBe('string')
+          expect(typeof topic.description).toBe('string')
         })
-      });
-  });
-});
+      })
+  })
+})
 describe('/api/articles/:article_id', () => {
   test('GET:200 sends a single article to the client', () => {
     return request(app)
       .get('/api/articles/1')
       .expect(200)
       .then(({ body }) => {
-        expect(body.article.article_id).toBe(1);
-        expect(body.article.title).toBe('Living in the shadow of a great man');
-        expect(body.article.author).toBe('butter_bridge');
-        expect(body.article.body).toBe('I find this existence challenging');
-        expect(body.article.topic).toBe('mitch');
-        expect(body.article.created_at).toBe("2020-07-09T20:11:00.000Z");
-        expect(body.article.votes).toBe(100);
-        expect(body.article.article_img_url).toBe('https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700');
-      });
-  });
+        expect(body.article.article_id).toBe(1)
+        expect(body.article.title).toBe('Living in the shadow of a great man')
+        expect(body.article.author).toBe('butter_bridge')
+        expect(body.article.body).toBe('I find this existence challenging')
+        expect(body.article.topic).toBe('mitch')
+        expect(body.article.created_at).toBe('2020-07-09T20:11:00.000Z')
+        expect(body.article.votes).toBe(100)
+        expect(body.article.article_img_url).toBe('https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700')
+      })
+  })
   test('GET:404 sends an appropriate status and error message when given a valid but non-existent id', () => {
     return request(app)
       .get('/api/articles/999')
       .expect(404)
       .then(({ body }) => {
-        expect(body.msg).toBe('Article does not exist');
-      });
-  });
+        expect(body.msg).toBe('Article does not exist')
+      })
+  })
   test('GET:400 sends an appropriate status and error message when given an invalid id', () => {
     return request(app)
       .get('/api/articles/not-a-article')
       .expect(400)
       .then(({ body }) => {
-        expect(body.msg).toBe('Bad request');
-      });
-  });
-  test("The '/api' endpoint to include a description of this new '/api/articles/:article_id' endpoint.", () => {
+        expect(body.msg).toBe('Bad Request')
+      })
+  })
+  test('The \'/api\' endpoint to include a description of this new \'/api/articles/:article_id\' endpoint.', () => {
     return request(app)
-      .get("/api")
-      .set("Accept", "application/json")
-      .expect("Content-Type", /json/)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
       .expect(200)
       .then(({ body }) => {
-        expect(body.endpoints["GET /api/articles/:article_id"]).toBeInstanceOf(Object);
-        expect(body.endpoints["GET /api/articles/:article_id"]).toEqual(endpoints["GET /api/articles/:article_id"]);
-      });
-  });
-});
+        expect(body.endpoints['GET /api/articles/:article_id'].exampleResponse).toBeInstanceOf(Object)
+        expect(body.endpoints['GET /api/articles/:article_id'].exampleResponse).toEqual(endpoints['GET /api/articles/:article_id'].exampleResponse)
+      })
+  })
+})
 describe('/api/articles', () => {
   test('GET:200 sends articles to the client', () => {
     return request(app)
       .get('/api/articles')
       .expect(200)
       .then(({ body }) => {
-        expect(body.articles).toBeInstanceOf(Array);
-        expect(body.articles.length > 0).toBe(true);
-        body.articles.forEach((article) =>{
-          expect(article).toBeInstanceOf(Object);
-          expect(typeof article.article_id).toBe('number');
-          expect(typeof article.title).toBe('string');
-          expect(typeof article.author).toBe('string');
-          expect(typeof article.topic).toBe('string');
-          expect(typeof article.created_at).toBe('string');
-          expect(typeof article.votes).toBe('number');
-          expect(typeof article.article_img_url).toBe('string');
-          expect(typeof article.comment_count).toBe('number');
+        expect(body.articles).toBeInstanceOf(Array)
+        expect(body.articles.length > 0).toBe(true)
+        body.articles.forEach((article) => {
+          expect(article).toBeInstanceOf(Object)
+          expect(typeof article.article_id).toBe('number')
+          expect(typeof article.title).toBe('string')
+          expect(typeof article.author).toBe('string')
+          expect(typeof article.topic).toBe('string')
+          expect(typeof article.created_at).toBe('string')
+          expect(typeof article.votes).toBe('number')
+          expect(typeof article.article_img_url).toBe('string')
+          expect(typeof article.comment_count).toBe('number')
         })
-      });
-  });
-});
+      })
+  })
+  test('GET:200 sends articles to the client sorted by date in descending order', () => {
+    return request(app)
+      .get('/api/articles')
+      .expect(200)
+      .then(({ body }) => {
+        const sortedArray = [...body.articles]
+        sortedArray.sort((a, b) => {
+          return Date.parse(b.created_at) - Date.parse(a.created_at)
+        })
+        expect(body.articles).toEqual(sortedArray)
+      })
+  })
+  test('GET:400 sends an appropriate status and error message when given an invalid id', () => {
+    return request(app)
+      .get('/api/articles/not-right-path')
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request')
+      })
+  })
+  test('The \'/api\' endpoint to include a description of this new \'/api/articles\' endpoint.', () => {
+    return request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.endpoints['GET /api/articles'].exampleResponse).toBeInstanceOf(Object)
+        expect(body.endpoints['GET /api/articles'].exampleResponse).toEqual(endpoints['GET /api/articles'].exampleResponse)
+      })
+  })
+})
+describe('/api/articles/:article_id/comments', () => {
+  test('GET:200 sends comments by article_id to the client', () => {
+    return request(app)
+      .get('/api/articles/1/comments')
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.comments).toBeInstanceOf(Array)
+        expect(body.comments.length > 0).toBe(true)
+        body.comments.forEach((comment) => {
+          expect(comment).toBeInstanceOf(Object)
+          expect(typeof comment.comment_id).toBe('number')
+          expect(typeof comment.votes).toBe('number')
+          expect(typeof comment.created_at).toBe('string')
+          expect(typeof comment.author).toBe('string')
+          expect(typeof comment.body).toBe('string')
+          expect(typeof comment.article_id).toBe('number')
+        })
+      })
+  })
+  test('GET:200 sends comments to the client sorted by date in descending order', () => {
+    return request(app)
+      .get('/api/articles/1/comments')
+      .expect(200)
+      .then(({ body }) => {
+        const sortedArray = [...body.comments]
+        sortedArray.sort((a, b) => {
+          return Date.parse(b.created_at) - Date.parse(a.created_at)
+        })
+        expect(body.comments).toEqual(sortedArray)
+      })
+  })
+  test('GET:400 sends an appropriate status and error message when given an invalid id', () => {
+    return request(app)
+      .get('/api/articles/not-valid-id/comments')
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request')
+      })
+  })
+  test('GET:404 sends an appropriate status and error message when given a valid but non-existent id', () => {
+    return request(app)
+      .get('/api/articles/999/comments')
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Comments does not exist')
+      })
+  })
+  test('The \'/api\' endpoint to include a description of this new \'/api/articles/:article_id/comments\' endpoint.', () => {
+    return request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.endpoints['GET /api/articles/:article_id/comments'].exampleResponse).toBeInstanceOf(Object)
+        expect(body.endpoints['GET /api/articles/:article_id/comments'].exampleResponse).toEqual(endpoints['GET /api/articles/:article_id/comments'].exampleResponse)
+      })
+  })
+})

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,12 +1,12 @@
-const request = require('supertest')
-const db = require('../db/connection')
-const seed = require('../db/seeds/seed')
-const testData = require('../db/data/test-data')
-const app = require('../app')
-const endpoints = require('../endpoints.json')
+const request = require('supertest');
+const db = require('../db/connection');
+const seed = require('../db/seeds/seed');
+const testData = require('../db/data/test-data');
+const app = require('../app');
+const endpoints = require('../endpoints.json');
 
-beforeEach(() => seed(testData))
-afterAll(() => db.end())
+beforeEach(() => seed(testData));
+afterAll(() => db.end());
 
 describe('GET /api', () => {
   test('Status 200, responds with endpoints data', () => {
@@ -16,11 +16,11 @@ describe('GET /api', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then(({ body }) => {
-        expect(body.endpoints).toBeInstanceOf(Object)
-        expect(body.endpoints).toEqual(endpoints)
-      })
-  })
-})
+        expect(body.endpoints).toBeInstanceOf(Object);
+        expect(body.endpoints).toEqual(endpoints);
+      });
+  });
+});
 describe('GET /api/topics', () => {
   test('Status 200, responds correct topic data', () => {
     return request(app)
@@ -29,169 +29,193 @@ describe('GET /api/topics', () => {
       .expect('Content-Type', /json/)
       .expect(200)
       .then(({ body }) => {
-        expect(body.topics).toBeInstanceOf(Array)
-        expect(body.topics.length > 0).toBe(true)
+        expect(body.topics).toBeInstanceOf(Array);
+        expect(body.topics.length > 0).toBe(true);
         body.topics.forEach((topic) => {
-          expect(topic).toBeInstanceOf(Object)
-          expect(typeof topic.slug).toBe('string')
-          expect(typeof topic.description).toBe('string')
-        })
-      })
-  })
-})
+          expect(topic).toBeInstanceOf(Object);
+          expect(typeof topic.slug).toBe('string');
+          expect(typeof topic.description).toBe('string');
+        });
+      });
+  });
+});
 describe('/api/articles/:article_id', () => {
   test('GET:200 sends a single article to the client', () => {
-    return request(app)
-      .get('/api/articles/1')
-      .expect(200)
-      .then(({ body }) => {
-        expect(body.article.article_id).toBe(1)
-        expect(body.article.title).toBe('Living in the shadow of a great man')
-        expect(body.article.author).toBe('butter_bridge')
-        expect(body.article.body).toBe('I find this existence challenging')
-        expect(body.article.topic).toBe('mitch')
-        expect(body.article.created_at).toBe('2020-07-09T20:11:00.000Z')
-        expect(body.article.votes).toBe(100)
-        expect(body.article.article_img_url).toBe('https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700')
-      })
-  })
-  test('GET:404 sends an appropriate status and error message when given a valid but non-existent id', () => {
-    return request(app)
-      .get('/api/articles/999')
-      .expect(404)
-      .then(({ body }) => {
-        expect(body.msg).toBe('Article does not exist')
-      })
-  })
-  test('GET:400 sends an appropriate status and error message when given an invalid id', () => {
-    return request(app)
-      .get('/api/articles/not-a-article')
-      .expect(400)
-      .then(({ body }) => {
-        expect(body.msg).toBe('Bad Request')
-      })
-  })
-  test('The \'/api\' endpoint to include a description of this new \'/api/articles/:article_id\' endpoint.', () => {
-    return request(app)
-      .get('/api')
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .then(({ body }) => {
-        expect(body.endpoints['GET /api/articles/:article_id'].exampleResponse).toBeInstanceOf(Object)
-        expect(body.endpoints['GET /api/articles/:article_id'].exampleResponse).toEqual(endpoints['GET /api/articles/:article_id'].exampleResponse)
-      })
-  })
-})
+    return request(app).get('/api/articles/1').expect(200).then(({ body }) => {
+      expect(body.article.article_id).toBe(1);
+      expect(body.article.title).toBe('Living in the shadow of a great man');
+      expect(body.article.author).toBe('butter_bridge');
+      expect(body.article.body).toBe('I find this existence challenging');
+      expect(body.article.topic).toBe('mitch');
+      expect(body.article.created_at).toBe('2020-07-09T20:11:00.000Z');
+      expect(body.article.votes).toBe(100);
+      expect(body.article.article_img_url).toBe(
+        'https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700');
+    });
+  });
+  test(
+    'GET:404 sends an appropriate status and error message when given a valid but non-existent id',
+    () => {
+      return request(app)
+        .get('/api/articles/999')
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe('Article does not exist');
+        });
+    });
+  test(
+    'GET:400 sends an appropriate status and error message when given an invalid id',
+    () => {
+      return request(app)
+        .get('/api/articles/not-a-article')
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe('Bad Request');
+        });
+    });
+  test(
+    'The \'/api\' endpoint to include a description of this new \'/api/articles/:article_id\' endpoint.',
+    () => {
+      return request(app)
+        .get('/api')
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then(({ body }) => {
+          expect(
+            body.endpoints['GET /api/articles/:article_id'].exampleResponse)
+            .toBeInstanceOf(Object);
+          expect(
+            body.endpoints['GET /api/articles/:article_id'].exampleResponse)
+            .toEqual(
+              endpoints['GET /api/articles/:article_id'].exampleResponse);
+        });
+    });
+});
 describe('/api/articles', () => {
   test('GET:200 sends articles to the client', () => {
-    return request(app)
-      .get('/api/articles')
-      .expect(200)
-      .then(({ body }) => {
-        expect(body.articles).toBeInstanceOf(Array)
-        expect(body.articles.length > 0).toBe(true)
-        body.articles.forEach((article) => {
-          expect(article).toBeInstanceOf(Object)
-          expect(typeof article.article_id).toBe('number')
-          expect(typeof article.title).toBe('string')
-          expect(typeof article.author).toBe('string')
-          expect(typeof article.topic).toBe('string')
-          expect(typeof article.created_at).toBe('string')
-          expect(typeof article.votes).toBe('number')
-          expect(typeof article.article_img_url).toBe('string')
-          expect(typeof article.comment_count).toBe('number')
-        })
-      })
-  })
-  test('GET:200 sends articles to the client sorted by date in descending order', () => {
-    return request(app)
-      .get('/api/articles')
-      .expect(200)
-      .then(({ body }) => {
-        const sortedArray = [...body.articles]
+    return request(app).get('/api/articles').expect(200).then(({ body }) => {
+      expect(body.articles).toBeInstanceOf(Array);
+      expect(body.articles.length > 0).toBe(true);
+      body.articles.forEach((article) => {
+        expect(article).toBeInstanceOf(Object);
+        expect(typeof article.article_id).toBe('number');
+        expect(typeof article.title).toBe('string');
+        expect(typeof article.author).toBe('string');
+        expect(typeof article.topic).toBe('string');
+        expect(typeof article.created_at).toBe('string');
+        expect(typeof article.votes).toBe('number');
+        expect(typeof article.article_img_url).toBe('string');
+        expect(typeof article.comment_count).toBe('number');
+      });
+    });
+  });
+  test(
+    'GET:200 sends articles to the client sorted by date in descending order',
+    () => {
+      return request(app).get('/api/articles').expect(200).then(({ body }) => {
+        const sortedArray = [...body.articles];
         sortedArray.sort((a, b) => {
-          return Date.parse(b.created_at) - Date.parse(a.created_at)
-        })
-        expect(body.articles).toEqual(sortedArray)
-      })
-  })
-  test('GET:400 sends an appropriate status and error message when given an invalid id', () => {
-    return request(app)
-      .get('/api/articles/not-right-path')
-      .expect(400)
-      .then(({ body }) => {
-        expect(body.msg).toBe('Bad Request')
-      })
-  })
-  test('The \'/api\' endpoint to include a description of this new \'/api/articles\' endpoint.', () => {
-    return request(app)
-      .get('/api')
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .then(({ body }) => {
-        expect(body.endpoints['GET /api/articles'].exampleResponse).toBeInstanceOf(Object)
-        expect(body.endpoints['GET /api/articles'].exampleResponse).toEqual(endpoints['GET /api/articles'].exampleResponse)
-      })
-  })
-})
+          return Date.parse(b.created_at) - Date.parse(a.created_at);
+        });
+        expect(body.articles).toEqual(sortedArray);
+      });
+    });
+  test(
+    'GET:400 sends an appropriate status and error message when given an invalid id',
+    () => {
+      return request(app)
+        .get('/api/articles/not-right-path')
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe('Bad Request');
+        });
+    });
+  test(
+    'The \'/api\' endpoint to include a description of this new \'/api/articles\' endpoint.',
+    () => {
+      return request(app)
+        .get('/api')
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.endpoints['GET /api/articles'].exampleResponse)
+            .toBeInstanceOf(Object);
+          expect(body.endpoints['GET /api/articles'].exampleResponse)
+            .toEqual(endpoints['GET /api/articles'].exampleResponse);
+        });
+    });
+});
 describe('/api/articles/:article_id/comments', () => {
   test('GET:200 sends comments by article_id to the client', () => {
     return request(app)
       .get('/api/articles/1/comments')
       .expect(200)
       .then(({ body }) => {
-        expect(body.comments).toBeInstanceOf(Array)
-        expect(body.comments.length > 0).toBe(true)
+        expect(body.comments).toBeInstanceOf(Array);
+        expect(body.comments.length > 0).toBe(true);
         body.comments.forEach((comment) => {
-          expect(comment).toBeInstanceOf(Object)
-          expect(typeof comment.comment_id).toBe('number')
-          expect(typeof comment.votes).toBe('number')
-          expect(typeof comment.created_at).toBe('string')
-          expect(typeof comment.author).toBe('string')
-          expect(typeof comment.body).toBe('string')
-          expect(typeof comment.article_id).toBe('number')
-        })
-      })
-  })
-  test('GET:200 sends comments to the client sorted by date in descending order', () => {
-    return request(app)
-      .get('/api/articles/1/comments')
-      .expect(200)
-      .then(({ body }) => {
-        const sortedArray = [...body.comments]
-        sortedArray.sort((a, b) => {
-          return Date.parse(b.created_at) - Date.parse(a.created_at)
-        })
-        expect(body.comments).toEqual(sortedArray)
-      })
-  })
-  test('GET:400 sends an appropriate status and error message when given an invalid id', () => {
-    return request(app)
-      .get('/api/articles/not-valid-id/comments')
-      .expect(400)
-      .then(({ body }) => {
-        expect(body.msg).toBe('Bad Request')
-      })
-  })
-  test('GET:404 sends an appropriate status and error message when given a valid but non-existent id', () => {
-    return request(app)
-      .get('/api/articles/999/comments')
-      .expect(404)
-      .then(({ body }) => {
-        expect(body.msg).toBe('Comments does not exist')
-      })
-  })
-  test('The \'/api\' endpoint to include a description of this new \'/api/articles/:article_id/comments\' endpoint.', () => {
-    return request(app)
-      .get('/api')
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .then(({ body }) => {
-        expect(body.endpoints['GET /api/articles/:article_id/comments'].exampleResponse).toBeInstanceOf(Object)
-        expect(body.endpoints['GET /api/articles/:article_id/comments'].exampleResponse).toEqual(endpoints['GET /api/articles/:article_id/comments'].exampleResponse)
-      })
-  })
-})
+          expect(comment).toBeInstanceOf(Object);
+          expect(typeof comment.comment_id).toBe('number');
+          expect(typeof comment.votes).toBe('number');
+          expect(typeof comment.created_at).toBe('string');
+          expect(typeof comment.author).toBe('string');
+          expect(typeof comment.body).toBe('string');
+          expect(typeof comment.article_id).toBe('number');
+        });
+      });
+  });
+  test(
+    'GET:200 sends comments to the client sorted by date in descending order',
+    () => {
+      return request(app)
+        .get('/api/articles/1/comments')
+        .expect(200)
+        .then(({ body }) => {
+          const sortedArray = [...body.comments];
+          sortedArray.sort((a, b) => {
+            return Date.parse(b.created_at) - Date.parse(a.created_at);
+          });
+          expect(body.comments).toEqual(sortedArray);
+        });
+    });
+  test(
+    'GET:400 sends an appropriate status and error message when given an invalid id',
+    () => {
+      return request(app)
+        .get('/api/articles/not-valid-id/comments')
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe('Bad Request');
+        });
+    });
+  test(
+    'GET:404 sends an appropriate status and error message when given a valid but non-existent id',
+    () => {
+      return request(app)
+        .get('/api/articles/999/comments')
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe('Comments does not exist');
+        });
+    });
+  test(
+    'The \'/api\' endpoint to include a description of this new \'/api/articles/:article_id/comments\' endpoint.',
+    () => {
+      return request(app)
+        .get('/api')
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .then(({ body }) => {
+          expect(
+            body.endpoints['GET /api/articles/:article_id/comments'].exampleResponse)
+            .toBeInstanceOf(Object);
+          expect(
+            body.endpoints['GET /api/articles/:article_id/comments'].exampleResponse)
+            .toEqual(
+              endpoints['GET /api/articles/:article_id/comments'].exampleResponse);
+        });
+    });
+});

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -2,100 +2,104 @@ const {
   convertTimestampToDate,
   createRef,
   formatComments,
-} = require("../db/seeds/utils");
+} = require('../db/seeds/utils');
 
-describe("convertTimestampToDate", () => {
-  test("returns a new object", () => {
+describe('convertTimestampToDate', () => {
+  test('returns a new object', () => {
     const timestamp = 1557572706232;
     const input = { created_at: timestamp };
     const result = convertTimestampToDate(input);
     expect(result).not.toBe(input);
     expect(result).toBeObject();
   });
-  test("converts a created_at property to a date", () => {
+  test('converts a created_at property to a date', () => {
     const timestamp = 1557572706232;
     const input = { created_at: timestamp };
     const result = convertTimestampToDate(input);
     expect(result.created_at).toBeDate();
     expect(result.created_at).toEqual(new Date(timestamp));
   });
-  test("does not mutate the input", () => {
+  test('does not mutate the input', () => {
     const timestamp = 1557572706232;
     const input = { created_at: timestamp };
     convertTimestampToDate(input);
     const control = { created_at: timestamp };
     expect(input).toEqual(control);
   });
-  test("ignores includes any other key-value-pairs in returned object", () => {
+  test('ignores includes any other key-value-pairs in returned object', () => {
     const input = { created_at: 0, key1: true, key2: 1 };
     const result = convertTimestampToDate(input);
     expect(result.key1).toBe(true);
     expect(result.key2).toBe(1);
   });
-  test("returns unchanged object if no created_at property", () => {
-    const input = { key: "value" };
+  test('returns unchanged object if no created_at property', () => {
+    const input = { key: 'value' };
     const result = convertTimestampToDate(input);
-    const expected = { key: "value" };
+    const expected = { key: 'value' };
     expect(result).toEqual(expected);
   });
 });
 
-describe("createRef", () => {
-  test("returns an empty object, when passed an empty array", () => {
+describe('createRef', () => {
+  test('returns an empty object, when passed an empty array', () => {
     const input = [];
     const actual = createRef(input);
     const expected = {};
     expect(actual).toEqual(expected);
   });
-  test("returns a reference object when passed an array with a single items", () => {
-    const input = [{ title: "title1", article_id: 1, name: "name1" }];
-    let actual = createRef(input, "title", "article_id");
-    let expected = { title1: 1 };
-    expect(actual).toEqual(expected);
-    actual = createRef(input, "name", "title");
-    expected = { name1: "title1" };
-    expect(actual).toEqual(expected);
-  });
-  test("returns a reference object when passed an array with many items", () => {
-    const input = [
-      { title: "title1", article_id: 1 },
-      { title: "title2", article_id: 2 },
-      { title: "title3", article_id: 3 },
-    ];
-    const actual = createRef(input, "title", "article_id");
-    const expected = { title1: 1, title2: 2, title3: 3 };
-    expect(actual).toEqual(expected);
-  });
-  test("does not mutate the input", () => {
-    const input = [{ title: "title1", article_id: 1 }];
-    const control = [{ title: "title1", article_id: 1 }];
+  test('returns a reference object when passed an array with a single items',
+    () => {
+      const input = [{ title: 'title1', article_id: 1, name: 'name1' }];
+      let actual = createRef(input, 'title', 'article_id');
+      let expected = { title1: 1 };
+      expect(actual).toEqual(expected);
+      actual = createRef(input, 'name', 'title');
+      expected = { name1: 'title1' };
+      expect(actual).toEqual(expected);
+    });
+  test('returns a reference object when passed an array with many items',
+    () => {
+      const input = [
+        { title: 'title1', article_id: 1 },
+        { title: 'title2', article_id: 2 },
+        { title: 'title3', article_id: 3 },
+      ];
+      const actual = createRef(input, 'title', 'article_id');
+      const expected = { title1: 1, title2: 2, title3: 3 };
+      expect(actual).toEqual(expected);
+    });
+  test('does not mutate the input', () => {
+    const input = [{ title: 'title1', article_id: 1 }];
+    const control = [{ title: 'title1', article_id: 1 }];
     createRef(input);
     expect(input).toEqual(control);
   });
 });
 
-describe("formatComments", () => {
-  test("returns an empty array, if passed an empty array", () => {
+describe('formatComments', () => {
+  test('returns an empty array, if passed an empty array', () => {
     const comments = [];
     expect(formatComments(comments, {})).toEqual([]);
     expect(formatComments(comments, {})).not.toBe(comments);
   });
-  test("converts created_by key to author", () => {
-    const comments = [{ created_by: "ant" }, { created_by: "bee" }];
+  test('converts created_by key to author', () => {
+    const comments = [{ created_by: 'ant' }, { created_by: 'bee' }];
     const formattedComments = formatComments(comments, {});
-    expect(formattedComments[0].author).toEqual("ant");
+    expect(formattedComments[0].author).toEqual('ant');
     expect(formattedComments[0].created_by).toBe(undefined);
-    expect(formattedComments[1].author).toEqual("bee");
+    expect(formattedComments[1].author).toEqual('bee');
     expect(formattedComments[1].created_by).toBe(undefined);
   });
-  test("replaces belongs_to value with appropriate id when passed a reference object", () => {
-    const comments = [{ belongs_to: "title1" }, { belongs_to: "title2" }];
-    const ref = { title1: 1, title2: 2 };
-    const formattedComments = formatComments(comments, ref);
-    expect(formattedComments[0].article_id).toBe(1);
-    expect(formattedComments[1].article_id).toBe(2);
-  });
-  test("converts created_at timestamp to a date", () => {
+  test(
+    'replaces belongs_to value with appropriate id when passed a reference object',
+    () => {
+      const comments = [{ belongs_to: 'title1' }, { belongs_to: 'title2' }];
+      const ref = { title1: 1, title2: 2 };
+      const formattedComments = formatComments(comments, ref);
+      expect(formattedComments[0].article_id).toBe(1);
+      expect(formattedComments[1].article_id).toBe(2);
+    });
+  test('converts created_at timestamp to a date', () => {
     const timestamp = Date.now();
     const comments = [{ created_at: timestamp }];
     const formattedComments = formatComments(comments, {});

--- a/app.js
+++ b/app.js
@@ -1,25 +1,26 @@
-const express = require('express')
-const app = express()
-const { getTopics } = require('./controllers/topics.controller')
-const { getEndpoints } = require('./controllers/endpoints.controller')
-const { getArticleById, getArticles, getCommentsByArticleId } = require('./controllers/articles.controller')
-const { AppError, InternalServerError } = require('./errors')
+const express = require('express');
+const app = express();
+const { getTopics } = require('./controllers/topics.controller');
+const { getEndpoints } = require('./controllers/endpoints.controller');
+const { getArticleById, getArticles, getCommentsByArticleId } = require(
+  './controllers/articles.controller');
+const { AppError, InternalServerError } = require('./errors');
 
-app.get('/api/', getEndpoints)
-app.get('/api/topics', getTopics)
-app.get('/api/articles', getArticles)
-app.get('/api/articles/:article_id', getArticleById)
-app.get('/api/articles/:article_id/comments', getCommentsByArticleId)
+app.get('/api/', getEndpoints);
+app.get('/api/topics', getTopics);
+app.get('/api/articles', getArticles);
+app.get('/api/articles/:article_id', getArticleById);
+app.get('/api/articles/:article_id/comments', getCommentsByArticleId);
 
 app.use((err, req, res, next) => {
   if (!(err instanceof AppError)) {
-    console.error(err)
-    err = new InternalServerError()
+    console.error(err);
+    err = new InternalServerError();
   }
 
   res.status(err.code).send({
-    msg: err.message
-  })
-})
+    msg: err.message,
+  });
+});
 
-module.exports = app
+module.exports = app;

--- a/app.js
+++ b/app.js
@@ -1,26 +1,25 @@
-const express = require('express');
-const app = express();
-const { getTopics } = require('./controllers/topics.controller');
+const express = require('express')
+const app = express()
+const { getTopics } = require('./controllers/topics.controller')
 const { getEndpoints } = require('./controllers/endpoints.controller')
-const { getArticleById, getArticles } = require('./controllers/articles.controller')
-const { AppError } = require('./errors')
+const { getArticleById, getArticles, getCommentsByArticleId } = require('./controllers/articles.controller')
+const { AppError, InternalServerError } = require('./errors')
 
-
-app.get('/api/', getEndpoints);
-app.get('/api/topics', getTopics);
-app.get('/api/articles', getArticles);
-app.get('/api/articles/:article_id', getArticleById);
+app.get('/api/', getEndpoints)
+app.get('/api/topics', getTopics)
+app.get('/api/articles', getArticles)
+app.get('/api/articles/:article_id', getArticleById)
+app.get('/api/articles/:article_id/comments', getCommentsByArticleId)
 
 app.use((err, req, res, next) => {
-  if(err instanceof AppError) {
-    res.status(err.code).send({
-      msg: err.message
-    });
-  } else {
-    res.status(500).send({
-      msg: 'Internal Server Error'
-    });
+  if (!(err instanceof AppError)) {
+    console.error(err)
+    err = new InternalServerError()
   }
+
+  res.status(err.code).send({
+    msg: err.message
+  })
 })
 
-module.exports = app;
+module.exports = app

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,22 +1,32 @@
-const { fetchArticleById, fetchArticles } = require('../models/articles.model')
+const { fetchArticleById, fetchArticles, fetchCommentsByArticleId } = require('../models/articles.model')
 
 const getArticleById = (request, response, next) => {
 
-  const { article_id } = request.params;
+  const { article_id } = request.params
 
   fetchArticleById(article_id).then((article) => {
-    response.status(200).send({article});
-  }).catch((err) =>{
-    next(err);
+    response.status(200).send({ article })
+  }).catch((err) => {
+    next(err)
   })
 }
 
 const getArticles = (request, response, next) => {
   fetchArticles().then((articles) => {
-    response.status(200).send({articles});
-  }).catch((err) =>{
-    next(err);
+    response.status(200).send({ articles })
+  }).catch((err) => {
+    next(err)
   })
 }
 
-module.exports = { getArticleById, getArticles };
+const getCommentsByArticleId = (request, response, next) => {
+  const { article_id } = request.params
+
+  fetchCommentsByArticleId(article_id).then((comments) => {
+    response.status(200).send({ comments })
+  }).catch((err) => {
+    next(err)
+  })
+}
+
+module.exports = { getArticleById, getArticles, getCommentsByArticleId }

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,32 +1,33 @@
-const { fetchArticleById, fetchArticles, fetchCommentsByArticleId } = require('../models/articles.model')
+const { fetchArticleById, fetchArticles, fetchCommentsByArticleId } = require(
+  '../models/articles.model');
 
 const getArticleById = (request, response, next) => {
 
-  const { article_id } = request.params
+  const { article_id } = request.params;
 
   fetchArticleById(article_id).then((article) => {
-    response.status(200).send({ article })
+    response.status(200).send({ article });
   }).catch((err) => {
-    next(err)
-  })
-}
+    next(err);
+  });
+};
 
 const getArticles = (request, response, next) => {
   fetchArticles().then((articles) => {
-    response.status(200).send({ articles })
+    response.status(200).send({ articles });
   }).catch((err) => {
-    next(err)
-  })
-}
+    next(err);
+  });
+};
 
 const getCommentsByArticleId = (request, response, next) => {
-  const { article_id } = request.params
+  const { article_id } = request.params;
 
   fetchCommentsByArticleId(article_id).then((comments) => {
-    response.status(200).send({ comments })
+    response.status(200).send({ comments });
   }).catch((err) => {
-    next(err)
-  })
-}
+    next(err);
+  });
+};
 
-module.exports = { getArticleById, getArticles, getCommentsByArticleId }
+module.exports = { getArticleById, getArticles, getCommentsByArticleId };

--- a/controllers/endpoints.controller.js
+++ b/controllers/endpoints.controller.js
@@ -1,11 +1,11 @@
-const { fetchEndpoints } = require('../models/endpoints.model')
+const { fetchEndpoints } = require('../models/endpoints.model');
 
 const getEndpoints = (request, response, next) => {
   fetchEndpoints().then((endpoints) => {
-    response.status(200).send({endpoints});
-  }).catch((err) =>{
+    response.status(200).send({ endpoints });
+  }).catch((err) => {
     next(err);
-  })
-}
+  });
+};
 
 module.exports = { getEndpoints };

--- a/controllers/topics.controller.js
+++ b/controllers/topics.controller.js
@@ -1,11 +1,11 @@
-const { fetchTopics } = require('../models/topics.model')
+const { fetchTopics } = require('../models/topics.model');
 
 const getTopics = (request, response, next) => {
   fetchTopics().then((topics) => {
-    response.status(200).send({topics});
-  }).catch((err) =>{
+    response.status(200).send({ topics });
+  }).catch((err) => {
     next(err);
-  })
-}
+  });
+};
 
 module.exports = { getTopics };

--- a/db/seeds/seed.js
+++ b/db/seeds/seed.js
@@ -7,35 +7,29 @@ const {
 } = require('./utils');
 
 const seed = ({ topicData, userData, articleData, commentData }) => {
-  return db
-    .query(`DROP TABLE IF EXISTS comments;`)
-    .then(() => {
-      return db.query(`DROP TABLE IF EXISTS articles;`);
-    })
-    .then(() => {
-      return db.query(`DROP TABLE IF EXISTS users;`);
-    })
-    .then(() => {
-      return db.query(`DROP TABLE IF EXISTS topics;`);
-    })
-    .then(() => {
-      const topicsTablePromise = db.query(`
+  return db.query(`DROP TABLE IF EXISTS comments;`).then(() => {
+    return db.query(`DROP TABLE IF EXISTS articles;`);
+  }).then(() => {
+    return db.query(`DROP TABLE IF EXISTS users;`);
+  }).then(() => {
+    return db.query(`DROP TABLE IF EXISTS topics;`);
+  }).then(() => {
+    const topicsTablePromise = db.query(`
       CREATE TABLE topics (
         slug VARCHAR PRIMARY KEY,
         description VARCHAR
       );`);
 
-      const usersTablePromise = db.query(`
+    const usersTablePromise = db.query(`
       CREATE TABLE users (
         username VARCHAR PRIMARY KEY,
         name VARCHAR NOT NULL,
         avatar_url VARCHAR
       );`);
 
-      return Promise.all([topicsTablePromise, usersTablePromise]);
-    })
-    .then(() => {
-      return db.query(`
+    return Promise.all([topicsTablePromise, usersTablePromise]);
+  }).then(() => {
+    return db.query(`
       CREATE TABLE articles (
         article_id SERIAL PRIMARY KEY,
         title VARCHAR NOT NULL,
@@ -46,9 +40,8 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
         votes INT DEFAULT 0 NOT NULL,
         article_img_url VARCHAR DEFAULT 'https://images.pexels.com/photos/97050/pexels-photo-97050.jpeg?w=700&h=700'
       );`);
-    })
-    .then(() => {
-      return db.query(`
+  }).then(() => {
+    return db.query(`
       CREATE TABLE comments (
         comment_id SERIAL PRIMARY KEY,
         body VARCHAR NOT NULL,
@@ -57,63 +50,60 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
         votes INT DEFAULT 0 NOT NULL,
         created_at TIMESTAMP DEFAULT NOW()
       );`);
-    })
-    .then(() => {
-      const insertTopicsQueryStr = format(
-        'INSERT INTO topics (slug, description) VALUES %L;',
-        topicData.map(({ slug, description }) => [slug, description])
-      );
-      const topicsPromise = db.query(insertTopicsQueryStr);
+  }).then(() => {
+    const insertTopicsQueryStr = format(
+      'INSERT INTO topics (slug, description) VALUES %L;',
+      topicData.map(({ slug, description }) => [slug, description]),
+    );
+    const topicsPromise = db.query(insertTopicsQueryStr);
 
-      const insertUsersQueryStr = format(
-        'INSERT INTO users ( username, name, avatar_url) VALUES %L;',
-        userData.map(({ username, name, avatar_url }) => [
-          username,
-          name,
-          avatar_url,
-        ])
-      );
-      const usersPromise = db.query(insertUsersQueryStr);
+    const insertUsersQueryStr = format(
+      'INSERT INTO users ( username, name, avatar_url) VALUES %L;',
+      userData.map(({ username, name, avatar_url }) => [
+        username,
+        name,
+        avatar_url,
+      ]),
+    );
+    const usersPromise = db.query(insertUsersQueryStr);
 
-      return Promise.all([topicsPromise, usersPromise]);
-    })
-    .then(() => {
-      const formattedArticleData = articleData.map(convertTimestampToDate);
-      const insertArticlesQueryStr = format(
-        'INSERT INTO articles (title, topic, author, body, created_at, votes, article_img_url) VALUES %L RETURNING *;',
-        formattedArticleData.map(
-          ({
-            title,
-            topic,
-            author,
-            body,
-            created_at,
-            votes = 0,
-            article_img_url,
-          }) => [title, topic, author, body, created_at, votes, article_img_url]
-        )
-      );
+    return Promise.all([topicsPromise, usersPromise]);
+  }).then(() => {
+    const formattedArticleData = articleData.map(convertTimestampToDate);
+    const insertArticlesQueryStr = format(
+      'INSERT INTO articles (title, topic, author, body, created_at, votes, article_img_url) VALUES %L RETURNING *;',
+      formattedArticleData.map(
+        ({
+          title,
+          topic,
+          author,
+          body,
+          created_at,
+          votes = 0,
+          article_img_url,
+        }) => [title, topic, author, body, created_at, votes, article_img_url],
+      ),
+    );
 
-      return db.query(insertArticlesQueryStr);
-    })
-    .then(({ rows: articleRows }) => {
-      const articleIdLookup = createRef(articleRows, 'title', 'article_id');
-      const formattedCommentData = formatComments(commentData, articleIdLookup);
+    return db.query(insertArticlesQueryStr);
+  }).then(({ rows: articleRows }) => {
+    const articleIdLookup = createRef(articleRows, 'title', 'article_id');
+    const formattedCommentData = formatComments(commentData, articleIdLookup);
 
-      const insertCommentsQueryStr = format(
-        'INSERT INTO comments (body, author, article_id, votes, created_at) VALUES %L;',
-        formattedCommentData.map(
-          ({ body, author, article_id, votes = 0, created_at }) => [
-            body,
-            author,
-            article_id,
-            votes,
-            created_at,
-          ]
-        )
-      );
-      return db.query(insertCommentsQueryStr);
-    });
+    const insertCommentsQueryStr = format(
+      'INSERT INTO comments (body, author, article_id, votes, created_at) VALUES %L;',
+      formattedCommentData.map(
+        ({ body, author, article_id, votes = 0, created_at }) => [
+          body,
+          author,
+          article_id,
+          votes,
+          created_at,
+        ],
+      ),
+    );
+    return db.query(insertCommentsQueryStr);
+  });
 };
 
 module.exports = seed;

--- a/endpoints.json
+++ b/endpoints.json
@@ -6,12 +6,22 @@
     "description": "serves an array of all topics",
     "queries": [],
     "exampleResponse": {
-      "topics": [{ "slug": "football", "description": "Footie!" }]
+      "topics": [
+        {
+          "slug": "football",
+          "description": "Footie!"
+        }
+      ]
     }
   },
   "GET /api/articles": {
     "description": "serves an array of all articles",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "queries": [
+      "author",
+      "topic",
+      "sort_by",
+      "order"
+    ],
     "exampleResponse": {
       "articles": [
         {
@@ -27,13 +37,33 @@
     }
   },
   "GET /api/articles/:article_id": {
-    "article_id": 1,
-    "title": "Living in the shadow of a great man",
-    "topic": "mitch",
-    "author": "butter_bridge",
-    "body": "I find this existence challenging",
-    "created_at": "2020-07-09T20:11:00.000Z",
-    "votes": 100,
-    "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+    "description": "serves an article by article_id",
+    "exampleResponse": {
+      "article": {
+        "article_id": 1,
+        "title": "Living in the shadow of a great man",
+        "topic": "mitch",
+        "author": "butter_bridge",
+        "body": "I find this existence challenging",
+        "created_at": "2020-07-09T20:11:00.000Z",
+        "votes": 100,
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+      }
+    }
+  },
+  "GET /api/articles/:article_id/comments": {
+    "description": "serves an array of all comments by article_id",
+    "exampleResponse": {
+      "comments": [
+        {
+          "comment_id": 5,
+          "body": "I hate streaming noses",
+          "article_id": 1,
+          "author": "icellusedkars",
+          "votes": 0,
+          "created_at": "2020-11-03T21:00:00.000Z"
+        }
+      ]
+    }
   }
 }

--- a/errors.js
+++ b/errors.js
@@ -9,7 +9,7 @@ class AppError extends Error {
 
 class BadRequestError extends AppError {
   constructor(message) {
-    super(message);
+    super(message || 'Bad Request');
 
     this.name = "BadRequestError";
     this.code = 400;
@@ -18,7 +18,7 @@ class BadRequestError extends AppError {
 
 class NotFoundError extends AppError {
   constructor(message) {
-    super(message);
+    super(message || 'Not Found');
 
     this.name = "NotFoundError";
     this.code = 404;
@@ -27,7 +27,7 @@ class NotFoundError extends AppError {
 
 class MethodNotAllowedError extends AppError {
   constructor(message) {
-    super(message);
+    super(message || 'Method Not Allowed');
 
     this.name = "MethodNotAllowedError";
     this.code = 405;
@@ -36,7 +36,7 @@ class MethodNotAllowedError extends AppError {
 
 class TeapotError extends AppError {
   constructor(message) {
-    super(message);
+    super(message || 'I\'m a teapot');
 
     this.name = "TeapotError";
     this.code = 418;
@@ -45,7 +45,7 @@ class TeapotError extends AppError {
 
 class UnprocessableEntityError extends AppError {
   constructor(message) {
-    super(message);
+    super(message || 'Unprocessable Entity');
 
     this.name = "UnprocessableEntityError";
     this.code = 422;
@@ -54,7 +54,7 @@ class UnprocessableEntityError extends AppError {
 
 class InternalServerError extends AppError {
   constructor(message) {
-    super(message);
+    super(message || 'Internal Server Error');
 
     this.name = "InternalServerError";
     this.code = 500;

--- a/errors.js
+++ b/errors.js
@@ -1,62 +1,62 @@
 class AppError extends Error {
-  constructor(message) {
+  constructor (message) {
     super(message);
 
-    this.name = "";
+    this.name = '';
     this.code = 0;
   }
 }
 
 class BadRequestError extends AppError {
-  constructor(message) {
+  constructor (message) {
     super(message || 'Bad Request');
 
-    this.name = "BadRequestError";
+    this.name = 'BadRequestError';
     this.code = 400;
   }
 }
 
 class NotFoundError extends AppError {
-  constructor(message) {
+  constructor (message) {
     super(message || 'Not Found');
 
-    this.name = "NotFoundError";
+    this.name = 'NotFoundError';
     this.code = 404;
   }
 }
 
 class MethodNotAllowedError extends AppError {
-  constructor(message) {
+  constructor (message) {
     super(message || 'Method Not Allowed');
 
-    this.name = "MethodNotAllowedError";
+    this.name = 'MethodNotAllowedError';
     this.code = 405;
   }
 }
 
 class TeapotError extends AppError {
-  constructor(message) {
+  constructor (message) {
     super(message || 'I\'m a teapot');
 
-    this.name = "TeapotError";
+    this.name = 'TeapotError';
     this.code = 418;
   }
 }
 
 class UnprocessableEntityError extends AppError {
-  constructor(message) {
+  constructor (message) {
     super(message || 'Unprocessable Entity');
 
-    this.name = "UnprocessableEntityError";
+    this.name = 'UnprocessableEntityError';
     this.code = 422;
   }
 }
 
 class InternalServerError extends AppError {
-  constructor(message) {
+  constructor (message) {
     super(message || 'Internal Server Error');
 
-    this.name = "InternalServerError";
+    this.name = 'InternalServerError';
     this.code = 500;
   }
 }
@@ -68,5 +68,5 @@ module.exports = {
   MethodNotAllowedError,
   TeapotError,
   UnprocessableEntityError,
-  InternalServerError
-}
+  InternalServerError,
+};

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -1,56 +1,53 @@
-const db = require('../db/connection')
-const { NotFoundError, BadRequestError } = require('../errors')
+const db = require('../db/connection');
+const { NotFoundError, BadRequestError } = require('../errors');
 
 const fetchArticleById = (article_id) => {
 
   if (!/^\d+$/.test(article_id)) {
-    throw new BadRequestError()
+    throw new BadRequestError();
   }
 
-  return db
-    .query('SELECT * FROM articles WHERE article_id = $1;', [article_id])
-    .then((result) => {
-      if (!result.rows[0]) {
-        throw new NotFoundError('Article does not exist')
-      }
-      return result.rows[0]
-    })
-}
+  return db.query('SELECT * FROM articles WHERE article_id = $1;',
+    [article_id]).then((result) => {
+    if (!result.rows[0]) {
+      throw new NotFoundError('Article does not exist');
+    }
+    return result.rows[0];
+  });
+};
 
 const fetchArticles = () => {
-  return db
-    .query(`select author, title, article_id, topic, created_at, votes, article_img_url,
+  return db.query(`select author, title, article_id, topic, created_at, votes, article_img_url,
       (
        SELECT count(*)
        FROM comments
        WHERE comments.article_id = articles.article_id
       ) AS comment_count
        FROM articles
-       ORDER BY created_at DESC;`)
-    .then((result) => {
-      if (!result.rows[0]) {
-        throw new NotFoundError('Articles does not exist')
-      }
-      return result.rows.map(row => {
-        row.comment_count = parseInt(row.comment_count)
-        return row
-      })
-    })
-}
+       ORDER BY created_at DESC;`).then((result) => {
+    if (!result.rows[0]) {
+      throw new NotFoundError('Articles does not exist');
+    }
+    return result.rows.map(row => {
+      row.comment_count = parseInt(row.comment_count);
+      return row;
+    });
+  });
+};
 
 const fetchCommentsByArticleId = (article_id) => {
   if (!/^\d+$/.test(article_id)) {
-    throw new BadRequestError()
+    throw new BadRequestError();
   }
 
-  return db
-    .query('SELECT * FROM comments WHERE article_id = $1 ORDER BY created_at DESC;', [article_id])
-    .then((result) => {
-      if (!result.rows[0]) {
-        throw new NotFoundError('Comments does not exist')
-      }
-      return result.rows
-    })
-}
+  return db.query(
+    'SELECT * FROM comments WHERE article_id = $1 ORDER BY created_at DESC;',
+    [article_id]).then((result) => {
+    if (!result.rows[0]) {
+      throw new NotFoundError('Comments does not exist');
+    }
+    return result.rows;
+  });
+};
 
-module.exports = { fetchArticleById, fetchArticles, fetchCommentsByArticleId }
+module.exports = { fetchArticleById, fetchArticles, fetchCommentsByArticleId };

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -1,24 +1,23 @@
-const db = require("../db/connection");
+const db = require('../db/connection')
 const { NotFoundError, BadRequestError } = require('../errors')
 
 const fetchArticleById = (article_id) => {
 
-  if(!/^\d+$/.test(article_id)){
-    throw new BadRequestError('Bad request');
+  if (!/^\d+$/.test(article_id)) {
+    throw new BadRequestError()
   }
 
   return db
     .query('SELECT * FROM articles WHERE article_id = $1;', [article_id])
     .then((result) => {
       if (!result.rows[0]) {
-        throw new NotFoundError('Article does not exist');
+        throw new NotFoundError('Article does not exist')
       }
       return result.rows[0]
-    });
+    })
 }
 
 const fetchArticles = () => {
-
   return db
     .query(`select author, title, article_id, topic, created_at, votes, article_img_url,
       (
@@ -30,13 +29,28 @@ const fetchArticles = () => {
        ORDER BY created_at DESC;`)
     .then((result) => {
       if (!result.rows[0]) {
-        throw new NotFoundError('Articles does not exist');
+        throw new NotFoundError('Articles does not exist')
       }
       return result.rows.map(row => {
-        row.comment_count = parseInt(row.comment_count);
-        return row;
+        row.comment_count = parseInt(row.comment_count)
+        return row
       })
-    });
+    })
 }
 
-module.exports = { fetchArticleById, fetchArticles };
+const fetchCommentsByArticleId = (article_id) => {
+  if (!/^\d+$/.test(article_id)) {
+    throw new BadRequestError()
+  }
+
+  return db
+    .query('SELECT * FROM comments WHERE article_id = $1 ORDER BY created_at DESC;', [article_id])
+    .then((result) => {
+      if (!result.rows[0]) {
+        throw new NotFoundError('Comments does not exist')
+      }
+      return result.rows
+    })
+}
+
+module.exports = { fetchArticleById, fetchArticles, fetchCommentsByArticleId }

--- a/models/endpoints.model.js
+++ b/models/endpoints.model.js
@@ -1,7 +1,7 @@
 const fetchEndpoints = () => {
   return new Promise((resolve) => {
     resolve(require('../endpoints.json'));
-  })
-}
+  });
+};
 
 module.exports = { fetchEndpoints };

--- a/models/topics.model.js
+++ b/models/topics.model.js
@@ -1,11 +1,9 @@
-const db = require("../db/connection");
+const db = require('../db/connection');
 
 const fetchTopics = () => {
-  return db
-    .query(`SELECT * FROM topics`)
-    .then((result) => {
-      return result.rows;
-    });
-}
+  return db.query(`SELECT * FROM topics`).then((result) => {
+    return result.rows;
+  });
+};
 
 module.exports = { fetchTopics };

--- a/server.js
+++ b/server.js
@@ -1,11 +1,10 @@
-const app = require("./app")
+const app = require('./app');
 const port = 3000;
 
 app.listen(port, (err) => {
-  if(err){
+  if (err) {
     console.log(err);
-  }
-  else{
+  } else {
     console.log(`listening on port ${port}`);
   }
 });


### PR DESCRIPTION
- Implemented the '/api/articles/:article_id/comments' endpoint to retrieve all comments associated with a specific article.
- The endpoint provides an array of comment objects, each containing: comment_id, votes, created_at, author, body, and the associated article_id.
- Configured the endpoint to return comments ordered by 'created_at' in descending order, displaying the most recent comments first.
- Incorporated error handling to address scenarios like non-existent article_id or invalid request parameters.
- Conducted thorough testing to ensure accurate retrieval of comments and effective error management.
- Updated the API documentation at '/api' with details of the new '/api/articles/:article_id/comments' endpoint, including expected properties of the comment objects and sorting behavior.
- Code was refactored.