### PR TITLE
Implement POST /api/articles/:article_id/comments for adding comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -39,7 +39,7 @@ describe('GET /api/topics', () => {
       });
   });
 });
-describe('/api/articles/:article_id', () => {
+describe('GET /api/articles/:article_id', () => {
   test('GET:200 sends a single article to the client', () => {
     return request(app).get('/api/articles/1').expect(200).then(({ body }) => {
       expect(body.article.article_id).toBe(1);
@@ -53,46 +53,40 @@ describe('/api/articles/:article_id', () => {
         'https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700');
     });
   });
-  test(
-    'GET:404 sends an appropriate status and error message when given a valid but non-existent id',
-    () => {
-      return request(app)
-        .get('/api/articles/999')
-        .expect(404)
-        .then(({ body }) => {
-          expect(body.msg).toBe('Article does not exist');
-        });
-    });
-  test(
-    'GET:400 sends an appropriate status and error message when given an invalid id',
-    () => {
-      return request(app)
-        .get('/api/articles/not-a-article')
-        .expect(400)
-        .then(({ body }) => {
-          expect(body.msg).toBe('Bad Request');
-        });
-    });
-  test(
-    'The \'/api\' endpoint to include a description of this new \'/api/articles/:article_id\' endpoint.',
-    () => {
-      return request(app)
-        .get('/api')
-        .set('Accept', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(200)
-        .then(({ body }) => {
-          expect(
-            body.endpoints['GET /api/articles/:article_id'].exampleResponse)
-            .toBeInstanceOf(Object);
-          expect(
-            body.endpoints['GET /api/articles/:article_id'].exampleResponse)
-            .toEqual(
-              endpoints['GET /api/articles/:article_id'].exampleResponse);
-        });
-    });
+  test('GET:404 sends an appropriate status and error message when given a valid but non-existent id', () => {
+    return request(app)
+      .get('/api/articles/999')
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Article does not exist');
+      });
+  });
+  test('GET:400 sends an appropriate status and error message when given an invalid id', () => {
+    return request(app)
+      .get('/api/articles/not-a-article')
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request');
+      });
+  });
+  test('The \'/api\' endpoint to include a description of this new \'/api/articles/:article_id\' endpoint.', () => {
+    return request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(({ body }) => {
+        expect(
+          body.endpoints['GET /api/articles/:article_id'].exampleResponse)
+          .toBeInstanceOf(Object);
+        expect(
+          body.endpoints['GET /api/articles/:article_id'].exampleResponse)
+          .toEqual(
+            endpoints['GET /api/articles/:article_id'].exampleResponse);
+      });
+  });
 });
-describe('/api/articles', () => {
+describe('GET /api/articles', () => {
   test('GET:200 sends articles to the client', () => {
     return request(app).get('/api/articles').expect(200).then(({ body }) => {
       expect(body.articles).toBeInstanceOf(Array);
@@ -110,44 +104,38 @@ describe('/api/articles', () => {
       });
     });
   });
-  test(
-    'GET:200 sends articles to the client sorted by date in descending order',
-    () => {
-      return request(app).get('/api/articles').expect(200).then(({ body }) => {
-        const sortedArray = [...body.articles];
-        sortedArray.sort((a, b) => {
-          return Date.parse(b.created_at) - Date.parse(a.created_at);
-        });
-        expect(body.articles).toEqual(sortedArray);
+  test('GET:200 sends articles to the client sorted by date in descending order', () => {
+    return request(app).get('/api/articles').expect(200).then(({ body }) => {
+      const sortedArray = [...body.articles];
+      sortedArray.sort((a, b) => {
+        return Date.parse(b.created_at) - Date.parse(a.created_at);
       });
+      expect(body.articles).toEqual(sortedArray);
     });
-  test(
-    'GET:400 sends an appropriate status and error message when given an invalid id',
-    () => {
-      return request(app)
-        .get('/api/articles/not-right-path')
-        .expect(400)
-        .then(({ body }) => {
-          expect(body.msg).toBe('Bad Request');
-        });
-    });
-  test(
-    'The \'/api\' endpoint to include a description of this new \'/api/articles\' endpoint.',
-    () => {
-      return request(app)
-        .get('/api')
-        .set('Accept', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(200)
-        .then(({ body }) => {
-          expect(body.endpoints['GET /api/articles'].exampleResponse)
-            .toBeInstanceOf(Object);
-          expect(body.endpoints['GET /api/articles'].exampleResponse)
-            .toEqual(endpoints['GET /api/articles'].exampleResponse);
-        });
-    });
+  });
+  test('GET:400 sends an appropriate status and error message when given an invalid id', () => {
+    return request(app)
+      .get('/api/articles/not-right-path')
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request');
+      });
+  });
+  test('The \'/api\' endpoint to include a description of this new \'/api/articles\' endpoint.', () => {
+    return request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.endpoints['GET /api/articles'].exampleResponse)
+          .toBeInstanceOf(Object);
+        expect(body.endpoints['GET /api/articles'].exampleResponse)
+          .toEqual(endpoints['GET /api/articles'].exampleResponse);
+      });
+  });
 });
-describe('/api/articles/:article_id/comments', () => {
+describe('GET /api/articles/:article_id/comments', () => {
   test('GET:200 sends comments by article_id to the client', () => {
     return request(app)
       .get('/api/articles/1/comments')
@@ -166,56 +154,96 @@ describe('/api/articles/:article_id/comments', () => {
         });
       });
   });
-  test(
-    'GET:200 sends comments to the client sorted by date in descending order',
-    () => {
-      return request(app)
-        .get('/api/articles/1/comments')
-        .expect(200)
-        .then(({ body }) => {
-          const sortedArray = [...body.comments];
-          sortedArray.sort((a, b) => {
-            return Date.parse(b.created_at) - Date.parse(a.created_at);
-          });
-          expect(body.comments).toEqual(sortedArray);
+  test('GET:200 sends comments to the client sorted by date in descending order', () => {
+    return request(app)
+      .get('/api/articles/1/comments')
+      .expect(200)
+      .then(({ body }) => {
+        const sortedArray = [...body.comments];
+        sortedArray.sort((a, b) => {
+          return Date.parse(b.created_at) - Date.parse(a.created_at);
         });
-    });
-  test(
-    'GET:400 sends an appropriate status and error message when given an invalid id',
-    () => {
-      return request(app)
-        .get('/api/articles/not-valid-id/comments')
-        .expect(400)
-        .then(({ body }) => {
-          expect(body.msg).toBe('Bad Request');
-        });
-    });
-  test(
-    'GET:404 sends an appropriate status and error message when given a valid but non-existent id',
-    () => {
-      return request(app)
-        .get('/api/articles/999/comments')
-        .expect(404)
-        .then(({ body }) => {
-          expect(body.msg).toBe('Comments does not exist');
-        });
-    });
-  test(
-    'The \'/api\' endpoint to include a description of this new \'/api/articles/:article_id/comments\' endpoint.',
-    () => {
-      return request(app)
-        .get('/api')
-        .set('Accept', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(200)
-        .then(({ body }) => {
-          expect(
-            body.endpoints['GET /api/articles/:article_id/comments'].exampleResponse)
-            .toBeInstanceOf(Object);
-          expect(
-            body.endpoints['GET /api/articles/:article_id/comments'].exampleResponse)
-            .toEqual(
-              endpoints['GET /api/articles/:article_id/comments'].exampleResponse);
-        });
-    });
+        expect(body.comments).toEqual(sortedArray);
+      });
+  });
+  test('GET:400 sends an appropriate status and error message when given an invalid id', () => {
+    return request(app)
+      .get('/api/articles/not-valid-id/comments')
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request');
+      });
+  });
+  test('GET:404 sends an appropriate status and error message when given a valid but non-existent id', () => {
+    return request(app)
+      .get('/api/articles/999/comments')
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Comments does not exist');
+      });
+  });
+  test('The \'/api\' endpoint to include a description of this new \'/api/articles/:article_id/comments\' endpoint.', () => {
+    return request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(({ body }) => {
+        expect(
+          body.endpoints['GET /api/articles/:article_id/comments'].exampleResponse)
+          .toBeInstanceOf(Object);
+        expect(
+          body.endpoints['GET /api/articles/:article_id/comments'].exampleResponse)
+          .toEqual(
+            endpoints['GET /api/articles/:article_id/comments'].exampleResponse);
+      });
+  });
+});
+describe('POST /api/articles/:article_id/comments', () => {
+  test('POST:200 should insert new comment to DB and return it', () => {
+    return request(app)
+      .post('/api/articles/1/comments').send({ username: 'butter_bridge', body: 'a cat' })
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.comment).toBeInstanceOf(Object);
+        expect(typeof body.comment.comment_id).toBe('number');
+        expect(typeof body.comment.body).toBe('string');
+        expect(typeof body.comment.article_id).toBe('number');
+        expect(typeof body.comment.author).toBe('string');
+        expect(typeof body.comment.votes).toBe('number');
+        expect(typeof body.comment.created_at).toBe('string');
+      });
+  });
+  test('POST:400 sends an appropriate status and error message when given an invalid article_id', () => {
+    return request(app)
+      .post('/api/articles/not-valid-id/comments').send({ username: 'butter_bridge', body: 'a cat' })
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request');
+      });
+  });
+  test('POST:500 sends an appropriate status and error message when given an invalid username', () => {
+    return request(app)
+      .post('/api/articles/1/comments').send({ username: 'this_user_name_doesn\'t_exist', body: 'I\'m not real user' })
+      .expect(500)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Internal Server Error');
+      });
+  });
+  test('The \'/api\' endpoint to include a description of this new POST \'/api/articles/:article_id/comments\' endpoint.', () => {
+    return request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(({ body }) => {
+        expect(
+          body.endpoints['POST /api/articles/:article_id/comments'].exampleResponse)
+          .toBeInstanceOf(Object);
+        expect(
+          body.endpoints['POST /api/articles/:article_id/comments'].exampleResponse)
+          .toEqual(
+            endpoints['POST /api/articles/:article_id/comments'].exampleResponse);
+      });
+  });
 });

--- a/app.js
+++ b/app.js
@@ -2,19 +2,20 @@ const express = require('express');
 const app = express();
 const { getTopics } = require('./controllers/topics.controller');
 const { getEndpoints } = require('./controllers/endpoints.controller');
-const { getArticleById, getArticles, getCommentsByArticleId } = require(
-  './controllers/articles.controller');
+const { getArticleById, getArticles } = require('./controllers/articles.controller');
 const { AppError, InternalServerError } = require('./errors');
+const { getCommentsByArticleId, createCommentByArticleId } = require('./controllers/comments.controller');
 
 app.get('/api/', getEndpoints);
 app.get('/api/topics', getTopics);
 app.get('/api/articles', getArticles);
 app.get('/api/articles/:article_id', getArticleById);
 app.get('/api/articles/:article_id/comments', getCommentsByArticleId);
+app.post('/api/articles/:article_id/comments', express.json(), createCommentByArticleId);
 
 app.use((err, req, res, next) => {
   if (!(err instanceof AppError)) {
-    console.error(err);
+    // console.error(err);
     err = new InternalServerError();
   }
 

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,4 +1,4 @@
-const { fetchArticleById, fetchArticles, fetchCommentsByArticleId } = require(
+const { fetchArticleById, fetchArticles } = require(
   '../models/articles.model');
 
 const getArticleById = (request, response, next) => {
@@ -20,14 +20,4 @@ const getArticles = (request, response, next) => {
   });
 };
 
-const getCommentsByArticleId = (request, response, next) => {
-  const { article_id } = request.params;
-
-  fetchCommentsByArticleId(article_id).then((comments) => {
-    response.status(200).send({ comments });
-  }).catch((err) => {
-    next(err);
-  });
-};
-
-module.exports = { getArticleById, getArticles, getCommentsByArticleId };
+module.exports = { getArticleById, getArticles };

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,0 +1,34 @@
+const { fetchCommentsByArticleId, insertCommentByArticleId } = require(
+  '../models/comments.model');
+const { fetchArticleById } = require('../models/articles.model');
+
+const getCommentsByArticleId = (request, response, next) => {
+  const { article_id } = request.params;
+
+  fetchCommentsByArticleId(article_id).then((comments) => {
+    response.status(200).send({ comments });
+  }).catch((err) => {
+    next(err);
+  });
+};
+
+const createCommentByArticleId = (request, response, next) => {
+  
+  const comment = {
+    article_id: request.params.article_id,
+    author: request.body.username,
+    body: request.body.body,
+  };
+
+  fetchArticleById(comment.article_id)
+    .then(() => insertCommentByArticleId(comment))
+    .then((comment) => {
+      response.status(200).send({ comment });
+    })
+    .catch((err) => {
+      next(err);
+    });
+
+};
+
+module.exports = { getCommentsByArticleId, createCommentByArticleId };

--- a/endpoints.json
+++ b/endpoints.json
@@ -65,5 +65,22 @@
         }
       ]
     }
+  },
+  "POST /api/articles/:article_id/comments": {
+    "description": "adds a comment for an article by username",
+    "requestBody": [
+      "username",
+      "body"
+    ],
+    "exampleResponse": {
+      "comment": {
+        "comment_id": 303,
+        "body": "A Cat",
+        "article_id": 1,
+        "author": "happyamy2016",
+        "votes": 0,
+        "created_at": "2024-01-16T22:31:04.613Z"
+      }
+    }
   }
 }

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -35,19 +35,4 @@ const fetchArticles = () => {
   });
 };
 
-const fetchCommentsByArticleId = (article_id) => {
-  if (!/^\d+$/.test(article_id)) {
-    throw new BadRequestError();
-  }
-
-  return db.query(
-    'SELECT * FROM comments WHERE article_id = $1 ORDER BY created_at DESC;',
-    [article_id]).then((result) => {
-    if (!result.rows[0]) {
-      throw new NotFoundError('Comments does not exist');
-    }
-    return result.rows;
-  });
-};
-
-module.exports = { fetchArticleById, fetchArticles, fetchCommentsByArticleId };
+module.exports = { fetchArticleById, fetchArticles };

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,0 +1,34 @@
+const db = require('../db/connection');
+const format = require('pg-format');
+const { NotFoundError, BadRequestError } = require('../errors');
+
+const fetchCommentsByArticleId = (article_id) => {
+  if (!/^\d+$/.test(article_id)) {
+    throw new BadRequestError();
+  }
+
+  return db.query(
+    'SELECT * FROM comments WHERE article_id = $1 ORDER BY created_at DESC;',
+    [article_id]).then((result) => {
+    if (!result.rows[0]) {
+      throw new NotFoundError('Comments does not exist');
+    }
+    return result.rows;
+  });
+};
+
+const insertCommentByArticleId = (comment) => {
+  const sql = format(
+    'INSERT INTO comments (body, author, article_id) VALUES %L RETURNING *;',
+    [
+      [
+        comment.body,
+        comment.author,
+        comment.article_id,
+      ],
+    ],
+  );
+  return db.query(sql).then((result) => result.rows[0]);
+};
+
+module.exports = { fetchCommentsByArticleId, insertCommentByArticleId };


### PR DESCRIPTION
- Added a new POST endpoint '/api/articles/:article_id/comments' to allow users to add comments to an article.
- The endpoint accepts a request body containing 'username' and 'body' of the comment.
- Ensured that the endpoint responds with the newly posted comment object.
- Incorporated error handling for various scenarios, including invalid article_id, missing or invalid request body parameters, and unauthorized username.
- Created tests to verify successful comment addition, handling of invalid inputs, and appropriate error responses.
- Updated the API documentation at '/api' to include this new POST endpoint, detailing its purpose, expected request format, and example response.
- Refactored getCommentsByArticleId and fetchCommentsByArticleId methods