### PR TITLE
Implement PATCH /api/articles/:article_id for article vote updates

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -49,8 +49,8 @@ describe('GET /api/articles/:article_id', () => {
       expect(body.article.topic).toBe('mitch');
       expect(body.article.created_at).toBe('2020-07-09T20:11:00.000Z');
       expect(body.article.votes).toBe(100);
-      expect(body.article.article_img_url).toBe(
-        'https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700');
+      expect(body.article.article_img_url)
+        .toBe('https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700');
     });
   });
   test('GET:404 sends an appropriate status and error message when given a valid but non-existent id', () => {
@@ -279,6 +279,97 @@ describe('POST /api/articles/:article_id/comments', () => {
           body.endpoints['POST /api/articles/:article_id/comments'].exampleResponse)
           .toEqual(
             endpoints['POST /api/articles/:article_id/comments'].exampleResponse);
+      });
+  });
+});
+describe('PATCH /api/articles/:article_id', () => {
+  test('PATCH:201 should update votes in DB by article_id and return it', () => {
+    return request(app)
+      .patch('/api/articles/1').send({ inc_votes: 1 })
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.article).toBeInstanceOf(Object);
+        expect(typeof body.article.article_id).toBe('number');
+        expect(typeof body.article.title).toBe('string');
+        expect(typeof body.article.author).toBe('string');
+        expect(typeof body.article.topic).toBe('string');
+        expect(typeof body.article.created_at).toBe('string');
+        expect(typeof body.article.votes).toBe('number');
+        expect(typeof body.article.article_img_url).toBe('string');
+
+        expect(body.article.votes).toBe(101);
+      });
+  });
+  test('PATCH:201 should decrement the current article\'s vote property by 110', () => {
+    return request(app)
+      .patch('/api/articles/1').send({ inc_votes: -110 })
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.article.votes).toBe(-10);
+      });
+  });
+  test('PATCH:201 should return correct body', () => {
+    return request(app)
+      .patch('/api/articles/1').send({ inc_votes: 20 })
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.article.article_id).toBe(1);
+        expect(body.article.title).toBe('Living in the shadow of a great man');
+        expect(body.article.author).toBe('butter_bridge');
+        expect(body.article.body).toBe('I find this existence challenging');
+        expect(body.article.topic).toBe('mitch');
+        expect(body.article.created_at).toBe('2020-07-09T20:11:00.000Z');
+        expect(body.article.votes).toBe(120);
+        expect(body.article.article_img_url)
+          .toBe('https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700');
+      });
+  });
+  test('PATCH:201 should ignore unused keys', () => {
+    return request(app)
+      .patch('/api/articles/1').send({ inc_votes: 20, anotherKey: 'ignore-me' })
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.article.anotherKey).toBe(undefined);
+      });
+  });
+  test('PATCH:400 sends an appropriate status and error message when given an invalid article_id', () => {
+    return request(app)
+      .patch('/api/articles/not-valid-id').send({ inc_votes: 20 })
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request');
+      });
+  });
+  test('PATCH:400 sends an appropriate status and error message when required key missed', () => {
+    return request(app)
+      .patch('/api/articles/1').send({})
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request');
+      });
+  });
+  test('PATCH:404 sends an appropriate status and error message when given an invalid article_id', () => {
+    return request(app)
+      .patch('/api/articles/999').send({ inc_votes: 35 })
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Article does not exist');
+      });
+  });
+  test('The \'/api\' endpoint to include a description of this new PATCH \'/api/articles/:article_id\' endpoint.', () => {
+    return request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(({ body }) => {
+        expect(
+          body.endpoints['PATCH /api/articles/:article_id'].exampleResponse)
+          .toBeInstanceOf(Object);
+        expect(
+          body.endpoints['PATCH /api/articles/:article_id'].exampleResponse)
+          .toEqual(
+            endpoints['PATCH /api/articles/:article_id'].exampleResponse);
       });
   });
 });

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const express = require('express');
 const app = express();
 const { getTopics } = require('./controllers/topics.controller');
 const { getEndpoints } = require('./controllers/endpoints.controller');
-const { getArticleById, getArticles } = require('./controllers/articles.controller');
+const { getArticleById, getArticles, updateVoteInArticleById } = require('./controllers/articles.controller');
 const { AppError, InternalServerError } = require('./errors');
 const { getCommentsByArticleId, createCommentByArticleId } = require('./controllers/comments.controller');
 
@@ -14,6 +14,7 @@ app.get('/api/articles', getArticles);
 app.get('/api/articles/:article_id', getArticleById);
 app.get('/api/articles/:article_id/comments', getCommentsByArticleId);
 app.post('/api/articles/:article_id/comments', createCommentByArticleId);
+app.patch('/api/articles/:article_id', updateVoteInArticleById);
 
 app.use((err, req, res, next) => {
   if (!(err instanceof AppError)) {

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,5 +1,5 @@
-const { fetchArticleById, fetchArticles } = require(
-  '../models/articles.model');
+const { fetchArticleById, fetchArticles, patchVoteInArticleById } = require('../models/articles.model');
+const { insertCommentByArticleId } = require('../models/comments.model');
 
 const getArticleById = (request, response, next) => {
 
@@ -20,4 +20,20 @@ const getArticles = (request, response, next) => {
   });
 };
 
-module.exports = { getArticleById, getArticles };
+const updateVoteInArticleById = (request, response, next) => {
+
+  const article = {
+    article_id: request.params.article_id,
+    inc_votes: request.body.inc_votes,
+  };
+
+  patchVoteInArticleById(article)
+    .then((article) => {
+      response.status(201).send({ article });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+module.exports = { getArticleById, getArticles, updateVoteInArticleById };

--- a/endpoints.json
+++ b/endpoints.json
@@ -82,5 +82,23 @@
         "created_at": "2024-01-16T22:31:04.613Z"
       }
     }
+  },
+  "PATCH /api/articles/:article_id": {
+    "description": "updates an article's vote by article_id",
+    "requestBody": {
+      "inc_votes": 10
+    },
+    "exampleResponse": {
+      "article": {
+        "article_id": 1,
+        "title": "Living in the shadow of a great man",
+        "topic": "mitch",
+        "author": "butter_bridge",
+        "body": "I find this existence challenging",
+        "created_at": "2020-07-09T20:11:00.000Z",
+        "votes": 110,
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+      }
+    }
   }
 }

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -1,8 +1,8 @@
 const db = require('../db/connection');
 const { NotFoundError, BadRequestError } = require('../errors');
+const format = require('pg-format');
 
 const fetchArticleById = (article_id) => {
-
   if (!/^\d+$/.test(article_id)) {
     throw new BadRequestError();
   }
@@ -35,4 +35,21 @@ const fetchArticles = () => {
   });
 };
 
-module.exports = { fetchArticleById, fetchArticles };
+const patchVoteInArticleById = (article) => {
+  return fetchArticleById(article.article_id).then(() => {
+
+    if (!Number.isInteger(article.inc_votes)) {
+      throw new BadRequestError();
+    }
+
+    const sql = `UPDATE articles SET votes = votes + $1 WHERE article_id = $2 RETURNING *`;
+
+    return db.query(sql, [article.inc_votes, article.article_id]).catch(() => {
+      throw new BadRequestError();
+    });
+  }).then((result) => {
+    return result.rows[0];
+  });
+};
+
+module.exports = { fetchArticleById, fetchArticles, patchVoteInArticleById };


### PR DESCRIPTION
- Added the PATCH endpoint '/api/articles/:article_id' to allow updating the vote count of an article.
- The endpoint accepts a request body in the form { inc_votes: newVote }, where newVote adjusts the vote count accordingly.
- Implemented logic to increment or decrement the article's vote property based on the 'newVote' value received.
- Ensured the endpoint responds with the updated article object after modifying the vote count.
- Incorporated error handling for various scenarios, such as invalid article_id, incorrect request body format, and attempts to update non-existent articles.
- Developed tests to ensure proper functionality of vote updates, including both incrementing and decrementing scenarios, and handling of all potential error cases.
- Updated the API documentation at '/api' to include this new PATCH endpoint, detailing its functionality, expected request format, and example response.