### PR TITLE
Implement PATCH /api/comments/:comment_id for vote updates

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -477,6 +477,111 @@ describe('PATCH /api/articles/:article_id', () => {
       });
   });
 });
+describe('PATCH /api/comments/:comment_id', () => {
+  test('PATCH:201 should update votes in DB by comment_id and return correct data type', () => {
+    return request(app)
+      .patch('/api/comments/1').send({ inc_votes: 1 })
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.comment).toBeInstanceOf(Object);
+        expect(body.comment).toHaveProperty('comment_id');
+        expect(body.comment).toHaveProperty('body');
+        expect(body.comment).toHaveProperty('article_id');
+        expect(body.comment).toHaveProperty('author');
+        expect(body.comment).toHaveProperty('created_at');
+        expect(body.comment).toHaveProperty('votes');
+        expect(typeof body.comment.comment_id).toBe('number');
+        expect(typeof body.comment.body).toBe('string');
+        expect(typeof body.comment.author).toBe('string');
+        expect(typeof body.comment.article_id).toBe('number');
+        expect(typeof body.comment.created_at).toBe('string');
+        expect(typeof body.comment.votes).toBe('number');
+      });
+  });
+  test('PATCH:201 should update votes in DB by comment_id and return correct data', () => {
+    return request(app)
+      .patch('/api/comments/1').send({ inc_votes: 2 })
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.comment).toHaveProperty('comment_id', 1);
+        expect(body.comment).toHaveProperty('body', 'Oh, I\'ve got compassion running out of my nose, pal! I\'m the Sultan of Sentiment!');
+        expect(body.comment).toHaveProperty('article_id', 9);
+        expect(body.comment).toHaveProperty('author', 'butter_bridge');
+        expect(body.comment).toHaveProperty('created_at', '2020-04-06T12:17:00.000Z');
+        expect(body.comment).toHaveProperty('votes', 18);
+      });
+  });
+  test('PATCH:201 should decrement the current comment\'s vote property by 100', () => {
+    return request(app)
+      .patch('/api/comments/1').send({ inc_votes: -100 })
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.comment.votes).toBe(-84);
+      });
+  });
+  test('PATCH:201 should return correct body', () => {
+    return request(app)
+      .patch('/api/comments/1').send({ inc_votes: 20 })
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.comment).toHaveProperty('comment_id', 1);
+        expect(body.comment).toHaveProperty('body', 'Oh, I\'ve got compassion running out of my nose, pal! I\'m the Sultan of Sentiment!');
+        expect(body.comment).toHaveProperty('article_id', 9);
+        expect(body.comment).toHaveProperty('author', 'butter_bridge');
+        expect(body.comment).toHaveProperty('created_at', '2020-04-06T12:17:00.000Z');
+        expect(body.comment).toHaveProperty('votes', 36);
+      });
+  });
+  test('PATCH:201 should ignore unused keys', () => {
+    return request(app)
+      .patch('/api/comments/1').send({ inc_votes: 20, anotherKey: 'ignore-me' })
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.comment.anotherKey).toBe(undefined);
+      });
+  });
+  test('PATCH:400 sends an appropriate status and error message when given an invalid comment_id', () => {
+    return request(app)
+      .patch('/api/comments/not-valid-id').send({ inc_votes: 20 })
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request');
+      });
+  });
+  test('PATCH:400 sends an appropriate status and error message when required key missed', () => {
+    return request(app)
+      .patch('/api/articles/1').send({})
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request');
+      });
+  });
+  test('PATCH:404 sends an appropriate status and error message when comment by comment_id does not exist ', () => {
+    return request(app)
+      .patch('/api/comments/999').send({ inc_votes: 35 })
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Comment does not exist');
+      });
+  });
+  test('The \'/api\' endpoint to include a description of this new PATCH \'/api/articles/:article_id\' endpoint.', () => {
+    return request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(({ body }) => {
+        expect(
+          body.endpoints['PATCH /api/comments/:comment_id'].exampleResponse)
+          .toBeInstanceOf(Object);
+        expect(
+          body.endpoints['PATCH /api/comments/:comment_id'].exampleResponse)
+          .toEqual(
+            endpoints['PATCH /api/comments/:comment_id'].exampleResponse);
+      });
+  });
+});
+
 describe('DELETE /api/comments/:comment_id', () => {
   test('DELETE:204 should delete comment in DB by comment_id and return status 204 and no content.', () => {
     return request(app)
@@ -575,7 +680,7 @@ describe('GET /api/users/:username', () => {
       expect(body.user).toHaveProperty('avatar_url', 'https://www.healthytherapies.com/wp-content/uploads/2016/06/Lime3.jpg');
     });
   });
-  test('GET:404 sends an appropriate status and error message when username doe\'s not exist', () => {
+  test('GET:404 sends an appropriate status and error message when username does not exist', () => {
     return request(app)
       .get('/api/users/not-valid-username')
       .expect(404)

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ const { getTopics } = require('./controllers/topics.controller');
 const { getEndpoints } = require('./controllers/endpoints.controller');
 const { getArticleById, getArticles, updateVoteInArticleById } = require('./controllers/articles.controller');
 const { AppError, InternalServerError } = require('./errors');
-const { getCommentsByArticleId, createCommentByArticleId, deleteCommentById } = require('./controllers/comments.controller');
+const { getCommentsByArticleId, createCommentByArticleId, deleteCommentById, updateVoteInCommentById } = require('./controllers/comments.controller');
 const { getUsers, getUserByUserName } = require('./controllers/users.controller');
 
 app.use(express.json());
@@ -17,6 +17,7 @@ app.get('/api/articles/:article_id/comments', getCommentsByArticleId);
 app.post('/api/articles/:article_id/comments', createCommentByArticleId);
 app.patch('/api/articles/:article_id', updateVoteInArticleById);
 app.delete('/api/comments/:comment_id', deleteCommentById);
+app.patch('/api/comments/:comment_id', updateVoteInCommentById);
 app.get('/api/users', getUsers);
 app.get('/api/users/:username', getUserByUserName);
 

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,6 +1,4 @@
-const { fetchCommentsByArticleId, insertCommentByArticleId, deleteCommentByIdFromDB } = require('../models/comments.model');
-const { BadRequestError, NotFoundError } = require('../errors');
-const db = require('../db/connection');
+const { fetchCommentsByArticleId, insertCommentByArticleId, deleteCommentByIdFromDB, patchVoteInCommentById } = require('../models/comments.model');
 
 const getCommentsByArticleId = (request, response, next) => {
   const { article_id } = request.params;
@@ -40,4 +38,20 @@ const deleteCommentById = (request, response, next) => {
   });
 };
 
-module.exports = { getCommentsByArticleId, createCommentByArticleId, deleteCommentById };
+const updateVoteInCommentById = (request, response, next) => {
+
+  const comment = {
+    comment_id: request.params.comment_id,
+    inc_votes: request.body.inc_votes,
+  };
+
+  patchVoteInCommentById(comment)
+    .then((comment) => {
+      response.status(201).send({ comment });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+module.exports = { getCommentsByArticleId, createCommentByArticleId, deleteCommentById, updateVoteInCommentById };

--- a/endpoints.json
+++ b/endpoints.json
@@ -104,6 +104,22 @@
   "DELETE /api/comments/:comment_id": {
     "description": "delete comment from DB by comment_id"
   },
+  "PATCH /api/comments/:comment_id": {
+    "description": "updates an comment's vote by comment_id",
+    "requestBody": {
+      "inc_votes": 10
+    },
+    "exampleResponse": {
+      "comment": {
+        "comment_id": 303,
+        "body": "A Cat",
+        "article_id": 1,
+        "author": "happyamy2016",
+        "votes": 10,
+        "created_at": "2024-01-16T22:31:04.613Z"
+      }
+    }
+  },
   "GET /api/users": {
     "description": "serves an array of all users",
     "queries": [],

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -57,7 +57,24 @@ const deleteCommentByIdFromDB = (comment_id) => {
       [comment_id]).then((result) => {
     });
   });
-  
+
 };
 
-module.exports = { fetchCommentsByArticleId, insertCommentByArticleId, fetchCommentByCommentId, deleteCommentByIdFromDB };
+const patchVoteInCommentById = (comment) => {
+  return fetchCommentByCommentId(comment.comment_id).then(() => {
+
+    if (!Number.isInteger(comment.inc_votes)) {
+      throw new BadRequestError();
+    }
+
+    const sql = `UPDATE comments SET votes = votes + $1 WHERE comment_id = $2 RETURNING *`;
+
+    return db.query(sql, [comment.inc_votes, comment.comment_id]).catch(() => {
+      throw new BadRequestError();
+    });
+  }).then((result) => {
+    return result.rows[0];
+  });
+};
+
+module.exports = { fetchCommentsByArticleId, insertCommentByArticleId, fetchCommentByCommentId, deleteCommentByIdFromDB, patchVoteInCommentById };

--- a/models/users.model.js
+++ b/models/users.model.js
@@ -1,5 +1,5 @@
 const db = require('../db/connection');
-const { BadRequestError, NotFoundError } = require('../errors');
+const { NotFoundError } = require('../errors');
 const format = require('pg-format');
 
 const fetchUsers = () => {


### PR DESCRIPTION
- Added the PATCH endpoint '/api/comments/:comment_id' to allow updating the vote count of a specific comment.
- The endpoint accepts a request body in the form { inc_votes: newVote } to increment or decrement the comment's vote property.
- Implemented logic to adjust the comment's vote count based on the 'newVote' value, handling both increments and decrements.
- Ensured the endpoint responds with the updated comment object after modifying the vote count.
- Incorporated error handling for scenarios such as invalid comment_id, incorrect request body format, and attempts to update non-existent comments.
- Created tests to verify the functionality of vote updates and error handling, covering both incrementing and decrementing scenarios.
- Updated the API documentation at '/api' to include this new PATCH endpoint, detailing its functionality, expected request format, and example response.