### PR TITLE
Implement POST /api/topics for adding new topics

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -39,6 +39,72 @@ describe('GET /api/topics', () => {
       });
   });
 });
+describe('POST /api/topics', () => {
+  test('POST:201 should insert new topic to DB and return it', () => {
+
+    const newTopic = {
+      slug: 'Cat',
+      description: 'This vibrant red cat boasts a striking ginger coat that shines in the sun, complemented by deep green eyes full of curiosity. Agile and graceful, it moves with confidence, its playful demeanor and melodious purr adding a touch of joy to its surroundings.',
+    };
+
+    return request(app).post('/api/topics').send(newTopic)
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.topic).toBeInstanceOf(Object);
+        expect(body.topic).toHaveProperty('slug', newTopic.slug);
+        expect(body.topic).toHaveProperty('description', newTopic.description);
+      });
+
+  });
+  test('POST:201 should ignore unused keys', () => {
+
+    const newTopic = {
+      slug: 'Cat',
+      description: 'This vibrant red cat boasts a striking ginger coat that shines in the sun, complemented by deep green eyes full of curiosity. Agile and graceful, it moves with confidence, its playful demeanor and melodious purr adding a touch of joy to its surroundings.',
+    };
+
+    newTopic.anotherKey = 'ignore-me';
+
+    return request(app)
+      .post('/api/topics').send(newTopic)
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.topic).toBeInstanceOf(Object);
+        expect(body.topic).toHaveProperty('slug', newTopic.slug);
+        expect(body.topic).toHaveProperty('description', newTopic.description);
+        expect(body.topic.anotherKey).toBe(undefined);
+      });
+  });
+  test('POST:400 sends an appropriate status and error message when required key missed', () => {
+
+    const newTopic = {
+      description: 'Cat',
+    };
+
+    return request(app)
+      .post('/api/topics').send(newTopic)
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe('Bad Request');
+      });
+  });
+  test('The \'/api\' endpoint to include a description of this new POST \'/api/topics\' endpoint.', () => {
+    return request(app)
+      .get('/api')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(({ body }) => {
+        expect(
+          body.endpoints['POST /api/topics'].exampleResponse)
+          .toBeInstanceOf(Object);
+        expect(
+          body.endpoints['POST /api/topics'].exampleResponse)
+          .toEqual(
+            endpoints['POST /api/topics'].exampleResponse);
+      });
+  });
+});
 describe('GET /api/articles/:article_id', () => {
   test('GET:200 sends a single article to the client', () => {
     return request(app).get('/api/articles/1').expect(200).then(({ body }) => {

--- a/controllers/topics.controller.js
+++ b/controllers/topics.controller.js
@@ -1,4 +1,4 @@
-const { fetchTopics } = require('../models/topics.model');
+const { fetchTopics, insertTopic } = require('../models/topics.model');
 
 const getTopics = (request, response, next) => {
   fetchTopics().then((topics) => {
@@ -8,4 +8,18 @@ const getTopics = (request, response, next) => {
   });
 };
 
-module.exports = { getTopics };
+const createNewTopic = (request, response, next) => {
+  const topic = {
+    slug: request.body.slug,
+    description: request.body.description,
+  };
+
+  insertTopic(topic)
+    .then((topic) => {
+      response.status(201).send({ topic });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+module.exports = { getTopics, createNewTopic };

--- a/endpoints.json
+++ b/endpoints.json
@@ -14,6 +14,21 @@
       ]
     }
   },
+  "POST /api/topics": {
+    "description": "creates a new topic",
+    "requestBody": [
+      "slug",
+      "description"
+    ],
+    "exampleResponse": {
+      "topics": [
+        {
+          "slug": "topic name here",
+          "description": "description here"
+        }
+      ]
+    }
+  },
   "GET /api/articles": {
     "description": "serves an array of all articles by queries",
     "queries": [

--- a/models/topics.model.js
+++ b/models/topics.model.js
@@ -1,4 +1,6 @@
 const db = require('../db/connection');
+const format = require('pg-format');
+const { BadRequestError } = require('../errors');
 
 const fetchTopics = () => {
   return db.query(`SELECT * FROM topics`).then((result) => {
@@ -6,4 +8,22 @@ const fetchTopics = () => {
   });
 };
 
-module.exports = { fetchTopics };
+const insertTopic = (topic) => {
+  const sql = format(
+    'INSERT INTO topics (slug, description) VALUES %L RETURNING *',
+    [
+      [
+        topic.slug,
+        topic.description,
+      ],
+    ],
+  );
+ 
+  return db.query(sql).catch(() => {
+    throw new BadRequestError();
+  }).then((result) => {
+    return result.rows[0];
+  });
+};
+
+module.exports = { fetchTopics, insertTopic };

--- a/routes/topics.router.js
+++ b/routes/topics.router.js
@@ -1,6 +1,8 @@
-const { getTopics } = require('../controllers/topics.controller');
+const { getTopics, createNewTopic } = require('../controllers/topics.controller');
 const topicsRouter = require('express').Router();
 
-topicsRouter.get('/', getTopics);
+topicsRouter.route('/')
+  .get(getTopics)
+  .post(createNewTopic);
 
 module.exports = topicsRouter;


### PR DESCRIPTION
- Created a new POST endpoint '/api/topics' to allow the addition of new topics.
- The endpoint accepts a request body containing a 'slug' and 'description' for the new topic.
- Configured the endpoint to return the topic object of the newly added topic, including both 'slug' and 'description'.
- Implemented error handling for various scenarios, including duplicate slugs, missing fields, and invalid data formats.
- Developed comprehensive tests to ensure the endpoint correctly processes valid requests, and handles error cases effectively.
- Updated the '/api' endpoint documentation to include this new POST endpoint, detailing its functionality, expected request body format, and example of the response.