### PR TITLE
Update API hosted link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ user data programmatically.
 
 ## Hosted Version
 
-The API is hosted at [nc-news-u5o8.onrender.com](https://nc-news-u5o8.onrender.com/api). Feel free to interact with the live version of the API.
+The API is hosted at [api.nc-news.viktorkhasenko.com/api](https://api.nc-news.viktorkhasenko.com/api). Feel free to interact with the live version of the API.
 
 ## Getting Started
 


### PR DESCRIPTION
The README.md file has been updated to reflect the change in the hosted API link. This comes after transitioning the API to be hosted on the domain api.nc-news.viktorkhasenko.com/api.